### PR TITLE
Strings  in double quotation marks display

### DIFF
--- a/Ruth/Chapter_1/exercise_1.12.4
+++ b/Ruth/Chapter_1/exercise_1.12.4
@@ -1,0 +1,8 @@
+Python 2.7.12 (default, Dec  4 2017, 14:50:18) 
+[GCC 5.4.0 20160609] on linux2
+Type "copyright", "credits" or "license()" for more information.
+>>> print("hello")
+hello
+>>> "hello"
+'hello'
+>>> 


### PR DESCRIPTION
Inside the Python Shell or IDLE the string is always displayed using single quotation marks. However, if you use the print()function only contents of the string is displayed.