### PR TITLE
How expressions are evaluated on the Python script.

### DIFF
--- a/Ruth/Chapter_1/display_eval.py
+++ b/Ruth/Chapter_1/display_eval.py
@@ -1,0 +1,3 @@
+(6 + 4 * 9) # this will not display the output on the prompt
+print(6 + 4 * 9) # this will display the output on the prompt
+

--- a/Ruth/Chapter_1/display_eval.py
+++ b/Ruth/Chapter_1/display_eval.py
@@ -1,3 +1,3 @@
-(6 + 4 * 9) # this will not display the output on the prompt
+6 + 4 * 9 # this will not display the output on the prompt
 print(6 + 4 * 9) # this will display the output on the prompt
 

--- a/Ruth/Chapter_1/exercise_1.12.6
+++ b/Ruth/Chapter_1/exercise_1.12.6
@@ -1,0 +1,11 @@
+Python 2.7.12 (default, Dec  4 2017, 14:50:18) 
+[GCC 5.4.0 20160609] on linux2
+Type "copyright", "credits" or "license()" for more information.
+>>> 6 + 4 * 9
+42
+>>> 
+==================== RESTART: /home/riri/exercise_1.12.6 ====================
+>>> 
+==================== RESTART: /home/riri/exercise_1.12.6 ====================
+42
+>>> 


### PR DESCRIPTION
To display the evaluation of an expression on the Python script, the print function must be used else nothing will be shown.